### PR TITLE
Correlate pc and pcc extensions with C/C++

### DIFF
--- a/args.go
+++ b/args.go
@@ -2,6 +2,8 @@
 package ctags
 
 var ctagsArgs = []string{
+	`--map-C++=+.pc`,
+	`--map-C++=+.pcc`,
 	`--regex-clojure=/def ([A-Za-z0-9_!?+*<>=-]+)/\1/v,variable/`,
 	`--regex-clojure=/defmacro ([A-Za-z0-9_!?+*<>=-]+)/\1/m,macro/`,
 	`--regex-clojure=/defprotocol ([A-Za-z0-9_!?+*<>=-]+)/\1/p,protocol/`,

--- a/ctagsdotd/c.ctags
+++ b/ctagsdotd/c.ctags
@@ -1,0 +1,3 @@
+# ctags already supports C/C++. Just map extra extensions
+--map-C++=+.pc
+--map-C++=+.pcc


### PR DESCRIPTION
Register .pc and .pcc files as C. This helps https://github.com/sourcegraph/customer/issues/124.