### PR TITLE
expose function to list language mappings

### DIFF
--- a/ctags.go
+++ b/ctags.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -67,7 +68,7 @@ func New(opts Options) (Parser, error) {
 
 	// Some languages cause issues in universal-ctags (eg markdown). Stick to an
 	// allowlist of known working languages.
-	args = append(args, "--languages=Basic,C,C#,C++,Clojure,Cobol,CSS,CUDA,D,Elixir,elm,Erlang,Go,GraphQL,Groovy,haskell,Java,JavaScript,Jsonnet,kotlin,Lisp,Lua,MatLab,ObjectiveC,OCaml,Pascal,Perl,Perl6,PHP,Powershell,Protobuf,Python,R,Ruby,Rust,scala,Scheme,Sh,swift,SystemVerilog,Tcl,Thrift,typescript,tsx,Verilog,VHDL,Vim")
+	args = append(args, "--languages="+strings.Join(SupportedLanguages[:], ","))
 
 	cmd := exec.Command(opts.Bin, args...)
 	in, err := cmd.StdinPipe()

--- a/ctags_test.go
+++ b/ctags_test.go
@@ -2,6 +2,7 @@ package ctags
 
 import (
 	"bufio"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -112,7 +113,8 @@ class A implements B extends C {
 				Path:       "com/sourcegraph/A.java",
 				Signature:  "()",
 			},
-		}}, {
+		},
+	}, {
 		path: "schema.graphql",
 		data: `
 schema {
@@ -219,5 +221,22 @@ func TestScanner(t *testing.T) {
 
 	if !cmp.Equal(got, want) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+	}
+}
+
+func TestLanguageMapping(t *testing.T) {
+	mapping, err := ListLanguageMappings(context.Background(), os.Getenv("CTAGS_COMMAND"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, ok := mapping["JavaScript"]
+	if !ok {
+		t.Fatalf("expected 'JavaScript' in mapping. Mapping: %v", mapping)
+	}
+
+	expectedList := []string{"*.js", "*.jsx", "*.mjs"}
+	if diff := cmp.Diff(list, expectedList); diff != "" {
+		t.Fatalf("unexpected mappings list for 'JavaScript': got=%v expected=%v", list, expectedList)
 	}
 }

--- a/language-mapping.go
+++ b/language-mapping.go
@@ -1,0 +1,50 @@
+package ctags
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var SupportedLanguages = [...]string{"Basic", "C", "C#", "C++", "Clojure", "Cobol", "CSS", "CUDA", "D", "Elixir", "elm", "Erlang", "Go", "GraphQL", "Groovy", "haskell", "Java", "JavaScript", "Jsonnet", "kotlin", "Lisp", "Lua", "MatLab", "ObjectiveC", "OCaml", "Pascal", "Perl", "Perl6", "PHP", "Powershell", "Protobuf", "Python", "R", "Ruby", "Rust", "scala", "Scheme", "Sh", "swift", "SystemVerilog", "Tcl", "Thrift", "typescript", "tsx", "Verilog", "VHDL", "Vim"}
+
+func ListLanguageMappings(ctx context.Context, bin string) (map[string][]string, error) {
+	if bin == "" {
+		bin = "universal-ctags"
+	}
+
+	args := make([]string, 0, len(ctagsArgs)+2)
+	args = append(args, ctagsArgs...)
+	args = append(args, "--languages="+strings.Join(SupportedLanguages[:], ","))
+	args = append(args, "--list-maps")
+
+	var (
+		stderr bytes.Buffer
+		stdout bytes.Buffer
+	)
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("running %s failed with exit code %d: %v", bin, cmd.ProcessState.ExitCode(), stderr.String())
+		}
+		return nil, fmt.Errorf("failed to start %s: %v", bin, err)
+	}
+
+	lines := strings.Split(stdout.String(), "\n")
+	mapping := make(map[string][]string, len(lines))
+	for _, line := range lines {
+		split := strings.SplitN(line, " ", 2)
+		if len(split) != 2 {
+			continue
+		}
+		mapping[split[0]] = strings.Fields(split[1])
+	}
+
+	return mapping, nil
+}

--- a/language-mapping.go
+++ b/language-mapping.go
@@ -18,7 +18,6 @@ func ListLanguageMappings(ctx context.Context, bin string) (map[string][]string,
 
 	args := make([]string, 0, len(ctagsArgs)+2)
 	args = append(args, ctagsArgs...)
-	args = append(args, "--languages="+strings.Join(SupportedLanguages[:], ","))
 	args = append(args, "--list-maps")
 
 	var (


### PR DESCRIPTION
Required as part of https://github.com/sourcegraph/sourcegraph/issues/31071, this PR exposes a function to list the language mappings registered with `universal-ctags` using the `--list-maps` flag. 