### PR TITLE
apex: remove regex rule for classes

### DIFF
--- a/ctagsdotd/apex.ctags
+++ b/ctagsdotd/apex.ctags
@@ -1,3 +1,2 @@
 --langmap=java:+.apex.cls.trigger
 --regex-java=/^[ \t]*(private|protected|global|public|webservice)?[ \t]*(static)?[ \t]*[a-zA-Z0-9_\.]+[ \t]*(<[ \t]*[a-zA-Z0-9_\.]+[ \t]*,[ \t]*[a-zA-Z0-9_\.]+[ \t]*>[ \t]*)?([a-zA-Z0-9_]+)[ \t]*[{][ \t]*(get|set)/\4/P,properties/i
---regex-java=/^[ \t]*(private|protected|global|public)?[ \t]*((with|without) sharing)?[ \t]*(abstract|virtual)?[ \t]*class[ \t]+([a-zA-Z0-9_]+)/\5/classes/i


### PR DESCRIPTION
This rule overwrites the already existing behavior of ctags, which is to
classify Java classes as "c". Classifying Java classes as "classes"
leads to unexpected behavior during scoring in Zoekt.

I assume apex.ctags exists to reuse Java's rules for Apex and augment
them with Apex specific rules. If that is the case we should be fine
with using the default behavior for classes and just introducing the
rule for "properties."

I might not have all the context, so there might be reason why we have
to classify Java classes as "classes"?

History: https://sourcegraph.com/search?q=context:%40sourcegraph+r:go-ctags+type:diff+file:apex.ctags&patternType=literal