### PR TITLE
Wait for zombie ctags process

### DIFF
--- a/ctags.go
+++ b/ctags.go
@@ -124,6 +124,7 @@ func (p *ctagsProcess) Close() {
 	_ = p.cmd.Process.Kill()
 	_ = p.outPipe.Close()
 	_ = p.in.Close()
+	_ = p.cmd.Wait()
 }
 
 func (p *ctagsProcess) read(rep *reply) error {


### PR DESCRIPTION
Zombie processes were accumulating because the parent wasn't [`wait`](https://linuxhint.com/wait_command_linux)ing for ctags.

```
$ ps auxww | grep ctags | wc
chrismwendt      91572   0.0  0.0        0      0 s000  Z+   12:27PM   0:00.00 (ctags)
chrismwendt      91568   0.0  0.0        0      0 s000  Z+   12:27PM   0:00.00 (ctags)
chrismwendt      91564   0.0  0.0        0      0 s000  Z+   12:27PM   0:00.00 (ctags)
...
```