### PR TITLE
tsx: less restrictive var matching

### DIFF
--- a/ctagsdotd/tsx.ctags
+++ b/ctagsdotd/tsx.ctags
@@ -13,7 +13,7 @@
 --regex-tsx=/^[ \t]*(export[ \t]+)?module[ \t]+([a-zA-Z0-9_$]+)/\2/n,module/
 --regex-tsx=/^[ \t]*(export[ \t]+)?(default[ \t]+)?(async[ \t]+)?function[ \t]+([a-zA-Z0-9_$]+)/\4/f,function/
 --regex-tsx=/^[ \t]*export[ \t]+(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/
---regex-tsx=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)[ \t]*=[ \t]*function[ \t]*[*]?[ \t]*\(\)/\2/v,variable/
+--regex-tsx=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/
 --regex-tsx=/^[ \t]*(export[ \t]+)?(public|protected|private)[ \t]+(static[ \t]+)?(abstract[ \t]+)?(((get|set)[ \t]+)|(async[ \t]+[*]*[ \t]*))?([a-zA-Z1-9_$]+)/\9/m,member/
 --regex-tsx=/^[ \t]*(export[ \t]+)?interface[ \t]+([a-zA-Z0-9_$]+)/\2/i,interface/
 --regex-tsx=/^[ \t]*(export[ \t]+)?type[ \t]+([a-zA-Z0-9_$]+)/\2/t,type/


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/issues/45800

With the current rules we don't recognize `isActive` in

```tsx
let isActive = a === b
```

because it is neither exported
```
--regex-tsx=/^[ \t]*export[ \t]+(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/2
```

nor is it an anonymous function
```
--regex-tsx=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)[ \t]*=[ \t]*function[ \t]*[*]?[ \t]*\(\)/\2/v,variable/
```

I am not sure about the motivation to exclude local vars. Maybe the intent was to limit the size of the tag files?

Replacing the latter rule with the following, more liberal one captures both, anonymous functions and unexported variables.

```
--regex-tsx=/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/

```

### Test plan
with [App.tsx](https://sourcegraph.com/github.com/remix-run/react-router/-/raw/examples/custom-filter-link/src/App.tsx)
```
universal-ctags --langdef=tsx --langmap=tsx:.tsx --regex-tsx="/^[ \t]*(var|let|const)[ \t]+([a-zA-Z0-9_$]+)/\2/v,variable/" -f - App.tsx
brand   App.tsx /^  let brand = searchParams.get("brand");$/;"  v
isActive        App.tsx /^  let isActive = searchParams.get("brand") === brand;$/;"     v
name    App.tsx /^          let name = `${snkr.brand} ${snkr.model} ${snkr.colorway}`;$/;"      v
name    App.tsx /^  let name = `${snkr.brand} ${snkr.model} ${snkr.colorway}`;$/;"      v
sneakers        App.tsx /^  const sneakers = React.useMemo(() => {$/;"  v
snkr    App.tsx /^  let snkr = getSneakerById(id);$/;"  v
```