### PR TITLE
Ctags support for visual basic .net

### DIFF
--- a/ctagsdotd/vbnet.ctags
+++ b/ctagsdotd/vbnet.ctags
@@ -1,0 +1,12 @@
+# See additional-language.ctags for maintaining this file
+--langdef=vbnet
+--langmap=vbnet:.vb
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Overloads|Overrides|Overridable|NotOverridable|MustOverride|Shared|Shadows|Async|Iterator)\s+)*\s*(?:Function|Sub)\s+([A-Z_0-9\[\]]*)\(.*?\)\s*(?:As\s+[\w.]+)?/\1/m,method/
+--regex-vbnet=/^(?i)\s*(?:(?:Default|Public|Private|Protected|Friend|Overloads|Overrides|Overridable|NotOverridable|MustOverride|Shared|Shadows|WriteOnly|ReadOnly|Iterator)\s+)*\s*(?:Property)\s+([A-Z_0-9\[\]]*)\s+As\s+/\1/p,property/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shared|Shadows|Custom)\s+)*\s*(?:Event)\s+([A-Z_0-9\[\]]*)/\1/e,event/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows|MustInherit|NotInheritable|Partial)\s+)*\s*(?:Class)\s+([A-Z_0-9\[\]]*)/\1/c,class/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows)\s+)*\s*(?:Interface)\s+([A-Z_0-9\[\]]*)/\1/i,interface/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows|Partial)\s+)*\s*(?:Structure)\s+([A-Z_0-9\[\]]*)/\1/s,struct/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows)\s+)*\s*(?:Enum)\s+([A-Z_0-9\[\]]*)/\1/e,enum/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Friend)\s+)*\s*(?:Module)\s+([A-Z_0-9\[\]]*)/\1/c,class/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Overloads|Shared|Shadows|Widening|Narrowing)\s+)*\s*(?:Operator)\s+([\+\-\*\/\\=<>a-z]+)/\1/m,method/

--- a/ctagsdotd/vbnet.ctags
+++ b/ctagsdotd/vbnet.ctags
@@ -1,12 +1,12 @@
-# See additional-language.ctags for maintaining this file
+# See additional-language.ctags for maintaining this file. The type member specification for VB.NET can be found at https://learn.microsoft.com/en-us/dotnet/visual-basic/reference/language-specification/type-members
 --langdef=vbnet
 --langmap=vbnet:.vb
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Overloads|Overrides|Overridable|NotOverridable|MustOverride|Shared|Shadows|Async|Iterator)\s+)*\s*(?:Function|Sub)\s+([A-Z_0-9\[\]]*)\(.*?\)\s*(?:As\s+[\w.]+)?/\1/m,method/
 --regex-vbnet=/^(?i)\s*(?:(?:Default|Public|Private|Protected|Friend|Overloads|Overrides|Overridable|NotOverridable|MustOverride|Shared|Shadows|WriteOnly|ReadOnly|Iterator)\s+)*\s*(?:Property)\s+([A-Z_0-9\[\]]*)\s+As\s+/\1/p,property/
---regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shared|Shadows|Custom)\s+)*\s*(?:Event)\s+([A-Z_0-9\[\]]*)/\1/e,event/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shared|Shadows|Custom)\s+)*\s*(?:Event)\s+([A-Z_0-9\[\]]*)/\1/E,event/
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows|MustInherit|NotInheritable|Partial)\s+)*\s*(?:Class)\s+([A-Z_0-9\[\]]*)/\1/c,class/
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows)\s+)*\s*(?:Interface)\s+([A-Z_0-9\[\]]*)/\1/i,interface/
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows|Partial)\s+)*\s*(?:Structure)\s+([A-Z_0-9\[\]]*)/\1/s,struct/
---regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows)\s+)*\s*(?:Enum)\s+([A-Z_0-9\[\]]*)/\1/e,enum/
+--regex-vbnet=/^(?i)\s*(?:(?:Public|Private|Protected|Friend|Shadows)\s+)*\s*(?:Enum)\s+([A-Z_0-9\[\]]*)/\1/g,enum/
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Friend)\s+)*\s*(?:Module)\s+([A-Z_0-9\[\]]*)/\1/c,class/
 --regex-vbnet=/^(?i)\s*(?:(?:Public|Overloads|Shared|Shadows|Widening|Narrowing)\s+)*\s*(?:Operator)\s+([\+\-\*\/\\=<>a-z]+)/\1/m,method/

--- a/language-mapping.go
+++ b/language-mapping.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var SupportedLanguages = [...]string{"Basic", "C", "C#", "C++", "Clojure", "Cobol", "CSS", "CUDA", "D", "Elixir", "elm", "Erlang", "Go", "GraphQL", "Groovy", "haskell", "Java", "JavaScript", "Jsonnet", "kotlin", "Lisp", "Lua", "MatLab", "ObjectiveC", "OCaml", "Pascal", "Perl", "Perl6", "PHP", "Powershell", "Protobuf", "Python", "R", "Ruby", "Rust", "scala", "Scheme", "Sh", "swift", "SystemVerilog", "Tcl", "Thrift", "typescript", "tsx", "Verilog", "VHDL", "Vim"}
+var SupportedLanguages = [...]string{"Basic", "C", "C#", "C++", "Clojure", "Cobol", "CSS", "CUDA", "D", "Elixir", "elm", "Erlang", "Go", "GraphQL", "Groovy", "haskell", "Java", "JavaScript", "Jsonnet", "kotlin", "Lisp", "Lua", "MatLab", "ObjectiveC", "OCaml", "Pascal", "Perl", "Perl6", "PHP", "Powershell", "Protobuf", "Python", "R", "Ruby", "Rust", "scala", "Scheme", "Sh", "swift", "SystemVerilog", "Tcl", "Thrift", "typescript", "tsx", "vbnet", "Verilog", "VHDL", "Vim"}
 
 func ListLanguageMappings(ctx context.Context, bin string) (map[string][]string, error) {
 	if bin == "" {


### PR DESCRIPTION
As I mentioned [here](https://github.com/sourcegraph/scip-dotnet/pull/26#issuecomment-1561937385) I was unable to isntall sg and it seems to me that I would need to reinstall windows to be able to properly set up the environment to develop.

I have followed [this](https://docs.sourcegraph.com/dev/how-to/add_support_for_a_language) guideline to add support for symbol search for visual basic .net and without a proper testing environment I have no idea if I did the right thing or not 😄.
I would kindly ask you @olafurpg or somebody else from Sourcegraph to take a look at this draft PR and help me test it and make it to the main branch if possible.

Notes: 

- I have not added support for fields as it seems to me that they have the same format as variable declarations. So, with a simple regex I would have created a lot of noise by reporting also variables as fields.
- https://github.com/sourcegraph/go-ctags/blob/main/ctagsdotd/additional-languages.ctags mentions to check if `ctagsKindToLSPSymbolKind` handles all the ctag kinds, however I was not able to find the correct place to check it so the PR might be missing something.
