### PR TITLE
Return non-fatal errors instead of logging

### DIFF
--- a/ctags.go
+++ b/ctags.go
@@ -227,7 +227,7 @@ func (p *ctagsProcess) Parse(name string, content []byte) ([]*Entry, error) {
 	if ok, err := p.post(&req, content); err != nil {
 		return nil, &ParseError{Message: "error posting ctags request", Fatal: true, Inner: err}
 	} else if !ok {
-		return nil, &ParseError{Message: "file is not utf-8 encoded"}
+		return nil, &ParseError{Message: "filename is too long"}
 	}
 
 	// 250 is a better guess for initial size

--- a/ctags.go
+++ b/ctags.go
@@ -30,8 +30,8 @@ type Entry struct {
 }
 
 type Parser interface {
-	// Parse passes the file contents to the ctags parses and returns parsed symbols. In
-	// case of failure, it returns a custom type *ParseError to indicate if the error is fatal.
+	// Parse passes the file contents to the ctags parses and returns parsed symbols. In case of failure,
+	// it returns a custom type *ParseError that distinguishes between fatal  and non-fatal errors.
 	Parse(path string, content []byte) ([]*Entry, error)
 
 	// Close closes the underlying ctags process. The parser cannot be reused after it's closed.

--- a/ctags.go
+++ b/ctags.go
@@ -225,7 +225,7 @@ func (p *ctagsProcess) Parse(name string, content []byte) ([]*Entry, error) {
 	}
 
 	if ok, err := p.post(&req, content); err != nil {
-		return nil, err
+		return nil, &ParseError{Message: "error posting ctags request", Fatal: true, Inner: err}
 	} else if !ok {
 		return nil, newParseError("filename is too long")
 	}

--- a/ctags.go
+++ b/ctags.go
@@ -221,13 +221,13 @@ func (p *ctagsProcess) Parse(name string, content []byte) ([]*Entry, error) {
 	}
 
 	if !utf8.Valid(content) {
-		return nil, newParseError("file is not utf-8 encoded")
+		return nil, &ParseError{Message: "file is not utf-8 encoded"}
 	}
 
 	if ok, err := p.post(&req, content); err != nil {
 		return nil, &ParseError{Message: "error posting ctags request", Fatal: true, Inner: err}
 	} else if !ok {
-		return nil, newParseError("filename is too long")
+		return nil, &ParseError{Message: "file is not utf-8 encoded"}
 	}
 
 	// 250 is a better guess for initial size
@@ -258,7 +258,7 @@ func (p *ctagsProcess) Parse(name string, content []byte) ([]*Entry, error) {
 				Signature:  rep.Signature,
 			})
 		default:
-			return nil, newFatalParseError(fmt.Sprintf("ctags unexpected response %s", rep.Typ))
+			return nil, &ParseError{Message: fmt.Sprintf("ctags unexpected response %s", rep.Typ), Fatal: true}
 		}
 	}
 }

--- a/ctags_test.go
+++ b/ctags_test.go
@@ -3,6 +3,7 @@ package ctags
 import (
 	"bufio"
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -117,12 +118,13 @@ func TestParseError(t *testing.T) {
 
 	for _, tc := range cases {
 		got, err := p.Parse(tc.path, []byte(tc.data))
-		if err == nil {
+		var parseErr *ParseError
+		if err == nil || !errors.As(err, &parseErr) {
 			t.Fatal("expected parse error")
 		}
 
-		if err.Fatal {
-			t.Fatalf("expected non-fatal error, but got %s", err.Message)
+		if parseErr.Fatal {
+			t.Fatalf("expected non-fatal error, but got %s", parseErr.Message)
 		}
 
 		t.Run(tc.path, func(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -1,24 +1,31 @@
 package ctags
 
+// ParseError is a custom error type that represents ctags parsing errors.
+// It distinguishes between fatal and non-fatal errors, which clients may
+// want to handle differently.
 type ParseError struct {
+	// The error message.
 	Message string
-	File    string
-	Fatal   bool
+
+	// Whether the error is fatal. This corresponds to the 'fatal' flag in ctags error responses.
+	Fatal bool
+
+	// An optional inner error.
+	Inner error
 }
 
 func (e *ParseError) Error() string {
 	return e.Message
 }
 
-func NewFatalError(msg string, file string) *ParseError {
-	return &ParseError{
-		Message: msg, File: file,
-		Fatal: true,
-	}
+func (p *ParseError) Unwrap() error {
+	return p.Inner
 }
 
-func NewError(msg string, file string) *ParseError {
-	return &ParseError{Message: msg, File: file,
-		Fatal: false,
-	}
+func newFatalParseError(msg string) *ParseError {
+	return &ParseError{Message: msg, Fatal: true}
+}
+
+func newParseError(msg string) *ParseError {
+	return &ParseError{Message: msg, Fatal: false}
 }

--- a/error.go
+++ b/error.go
@@ -21,11 +21,3 @@ func (e *ParseError) Error() string {
 func (p *ParseError) Unwrap() error {
 	return p.Inner
 }
-
-func newFatalParseError(msg string) *ParseError {
-	return &ParseError{Message: msg, Fatal: true}
-}
-
-func newParseError(msg string) *ParseError {
-	return &ParseError{Message: msg, Fatal: false}
-}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,24 @@
+package ctags
+
+type ParseError struct {
+	Message string
+	File    string
+	Fatal   bool
+}
+
+func (e *ParseError) Error() string {
+	return e.Message
+}
+
+func NewFatalError(msg string, file string) *ParseError {
+	return &ParseError{
+		Message: msg, File: file,
+		Fatal: true,
+	}
+}
+
+func NewError(msg string, file string) *ParseError {
+	return &ParseError{Message: msg, File: file,
+		Fatal: false,
+	}
+}

--- a/parse_error.go
+++ b/parse_error.go
@@ -1,5 +1,7 @@
 package ctags
 
+import "fmt"
+
 // ParseError is a custom error type that represents ctags parsing errors.
 // It distinguishes between fatal and non-fatal errors, which clients may
 // want to handle differently.
@@ -15,7 +17,11 @@ type ParseError struct {
 }
 
 func (e *ParseError) Error() string {
-	return e.Message
+	if e.Inner != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Inner.Error())
+	} else {
+		return e.Message
+	}
 }
 
 func (p *ParseError) Unwrap() error {


### PR DESCRIPTION
Universal ctags distinguishes between two types of error:
* Fatal: user command is invalid or incorrectly formatted, I/O errors. This
indicates a big issue in how ctags is being called.
* Non-fatal: file parsing issues like invalid UTF-8, unsupported language, or
all symbols can't be parsed)

Currently, we only return fatal errors and just log non-fatal errors at "info".
Instead, we should return an error in both of these cases, and let the callers
decide how they want to handle it. For example, maybe we want to record an
error in observability.

This PR introduces a new struct in the API called `ParseError` which callers
can check to see if the error was fatal, and what file triggered the error.
It's an API break, but I think it's fine as this repo is intended only for
Sourcegraph use.